### PR TITLE
password-store: fix merge

### DIFF
--- a/800.renames-and-merges/p.yaml
+++ b/800.renames-and-merges/p.yaml
@@ -52,7 +52,7 @@
 - { setname: passenger,                name: ["ruby:passenger-apache", "ruby:passenger-nginx", "nginx:passenger","apmod:ruby26-passenger","ruby:passenger"], addflavor: true }
 - { setname: passes,                   name: passes-gtk, addflavor: true }
 - { setname: password-store,           name: [passwordstore] }
-- { setname: password-store,           name: [emacs-password-store,"emacs:password-store"], addflavor: emacs }
+- { setname: password-store,           name: "emacs:password-store", addflavor: emacs }
 - { setname: pastel,                   name: [rust:$0, python:$0, ruby:$0] }
 - { setname: pastel,                   name: jappis-pastel }
 - { setname: pasystray,                name: [pasystray-gtk2,pasystray-gtk2-standalone,pasystray-gtk3,pasystray-gtk3-standalone,pasystray-wayland] }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated the password-store mapping from multiple aliases to a single canonical target, simplifying normalization and lookup behavior.
  * Lookups that previously matched multiple alias entries now resolve only to the canonical target, which may change results for ambiguous names.
  * Existing alias names are no longer recognized; update any configurations or references to use the canonical name to ensure consistent resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->