### PR TITLE
gettext: fix merge

### DIFF
--- a/800.renames-and-merges/gettext.yaml
+++ b/800.renames-and-merges/gettext.yaml
@@ -24,7 +24,6 @@
 - setname: gettext
   name:
     - "emacs:po-mode"
-    - emacs-po-mode
     - gettext-po-mode
     - po-mode
     - po-mode.el


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed the deprecated “emacs-po-mode” alias from the gettext group to align with supported modes.
  * May affect projects relying on that alias for automatic detection; configure a supported mode if needed.
  * Clarifies configuration by consolidating supported names and preventing unintended matches.
  * No impact on other gettext-related names; all other mappings remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->